### PR TITLE
Start to upgrade to nightly Rust

### DIFF
--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1,10 +1,9 @@
 #![crate_name="free_macros"]
 #![crate_type="lib"]
 
-#![license = "MIT"]
 #![doc(html_root_url = "http://www.rust-ci.org/epsilonz/free.rs/doc/free/")]
 
-#![feature(macro_rules)]
 #![feature(unboxed_closures)]
+#![feature(box_syntax)]
 
 pub mod free;

--- a/src/free/trampoline.rs
+++ b/src/free/trampoline.rs
@@ -1,18 +1,18 @@
-pub type Sig<'a, X> = Box<FnOnce<(), X> + 'a>;
+pub type Sig<'a, X> = Box<FnOnce() -> X + 'a>;
 
 fn map<'a, X, Y, F:'a>(m: Sig<'a, X>, f: F) -> Sig<'a, Y>
     where
         F: FnOnce(X) -> Y,
 {
-    box move |:| f(m.call_once(()))
+    box move || f(m.call_once(()))
 }
 
-monad!(Trampoline, Sig, map, [])
+monad!(Trampoline, Sig, map, []);
 
 impl<'a, X:'a> Trampoline<'a, X> {
     #[inline]
     pub fn run(self) -> X {
-        self.go(|&:sbmx: Sig<'a, Box<_>>| *sbmx.call_once(()))
+        self.go(|sbmx: Sig<'a, Box<_>>| *sbmx.call_once(()))
     }
 }
 
@@ -23,5 +23,5 @@ pub fn done<'a, X>(a: X) -> Trampoline<'a, X> {
 
 #[inline(always)]
 pub fn more<'a, X>(ma: Sig<'a, Trampoline<'a, X>>) -> Trampoline<'a, X> {
-    wrap(map(ma, |:tx| box tx))
+    wrap(map(ma, |tx| box tx))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,14 @@
 #![crate_name="free"]
 #![crate_type="lib"]
 
-#![license = "MIT"]
 #![doc(html_root_url = "http://www.rust-ci.org/epsilonz/free.rs/doc/free/")]
 
 #![feature(phase)]
 #![feature(unboxed_closures)]
+#![feature(box_syntax)]
+#![feature(box_patterns)]
 
-#[phase(link, plugin)]
+#[macro_use]
 extern crate free_macros;
 
 pub mod free;


### PR DESCRIPTION
Hey there! I'm randomly looking at crates on crates.io that don't compile, and today, picked yours.

This PR doesn't _quite_ get this building with today's Rust, I'm running across an error I don't quite understand:

```
<free_macros macros>:33:47: 34:23 error: wrong number of type arguments: expected 1, found 2 [E0244]
<free_macros macros>:33 : 'a , Y : 'a , F : 'a > ( f : F , ) -> Box < FnOnce < ( Opaque , ) , _M < 'a
<free_macros macros>:34 , $ ( $ ctx , ) * Y >> + 'a > where F : FnOnce ( X ) -> _M < 'a , $ ( $ ctx ,
<free_macros macros>:1:1: 101:8 note: in expansion of monad!
src/free/trampoline.rs:10:1: 10:34 note: expansion site
<free_macros macros>:33:47: 34:23 help: run `rustc --explain E0244` to see a detailed explanation
<free_macros macros>:33:47: 34:28 error: the value of the associated type `Output` (from the trait `core::ops::FnOnce`) must be specified [E0191]
<free_macros macros>:33 : 'a , Y : 'a , F : 'a > ( f : F , ) -> Box < FnOnce < ( Opaque , ) , _M < 'a
<free_macros macros>:34 , $ ( $ ctx , ) * Y >> + 'a > where F : FnOnce ( X ) -> _M < 'a , $ ( $ ctx ,
<free_macros macros>:1:1: 101:8 note: in expansion of monad!
src/free/trampoline.rs:10:1: 10:34 note: expansion site
error: aborting due to 2 previous errors
```

Was wondering if you would be interested in getting this compiling again :)